### PR TITLE
VIR-34 Update Vireo Service Heap

### DIFF
--- a/vireo.service
+++ b/vireo.service
@@ -7,7 +7,7 @@ Type=exec
 User=vireo
 Group=vireo
 WorkingDirectory=/opt/vireo/Vireo
-ExecStart=/usr/bin/mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Xms2048m -Xmx2048m"
+ExecStart=/usr/bin/mvn clean spring-boot:run -Dspring-boot.run.jvmArguments="-Xms2048m -Xmx4096m"
 ExecStartPost=/bin/sh -c 'echo $MAINPID > /opt/vireo/vireo.pid'
 ExecStop=/bin/kill -TERM $MAINPID
 ExecStopPost=/bin/rm -f /opt/vireo/vireo.pid


### PR DESCRIPTION
This change updates the `vireo.service` file max heap size from 2048MB to 4096MB.