### PR TITLE
fix: org reviewer page

### DIFF
--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -113,8 +113,10 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
             title += ` (${degree} - ${major})`;
         } else if (degree) {
             title += ` (${degree})`;
-        } else if (submission.organization.name) {
-            title += ` (${submission.organization.name})`;
+        }
+
+        if (submission.organization && submission.organization.name) {
+            title += ` - ${submission.organization.name}`;
         }
 
         return title;

--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -113,10 +113,8 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
             title += ` (${degree} - ${major})`;
         } else if (degree) {
             title += ` (${degree})`;
-        }
-
-        if (submission.organization && submission.organization.name) {
-            title += ` - ${submission.organization.name}`;
+        } else if (submission.organization.name) {
+            title += ` (${submission.organization.name})`;
         }
 
         return title;

--- a/src/main/webapp/app/views/admin/info/workflowStep.html
+++ b/src/main/webapp/app/views/admin/info/workflowStep.html
@@ -7,6 +7,12 @@
 </div>
 <div class="col-md-6 col-sm-12 info-col">
   <ul class="info-list">
+    <li class="list-unstyled" ng-if="submission.organization && workflowStep.name === 'Personal Information'">
+      <div class="info-item">
+        <strong>Organization</strong>
+        <div>{{submission.organization.name}}</div>
+      </div>
+    </li>
     <li class="list-unstyled" ng-repeat="fieldProfile in workflowStep.aggregateFieldProfiles | filter:{enabled: true}" ng-if="$index >= (workflowStep.aggregateFieldProfiles.length / 2) && fieldProfile.inputType.name !== 'INPUT_FILE'">
       <submission-info type="view" submission="submission" field-profile="fieldProfile" label="{{fieldProfile.gloss=='Proquest Publication' ? 'Proquest Release' : fieldProfile.gloss}}" show-vocabulary-word="showVocabularyWord"></submission-info>
     </li>

--- a/src/main/webapp/app/views/admin/info/workflowStep.html
+++ b/src/main/webapp/app/views/admin/info/workflowStep.html
@@ -8,9 +8,13 @@
 <div class="col-md-6 col-sm-12 info-col">
   <ul class="info-list">
     <li class="list-unstyled" ng-if="submission.organization && workflowStep.name === 'Personal Information'">
-      <div class="info-item">
-        <strong>Organization</strong>
-        <div>{{submission.organization.name}}</div>
+      <div class="info-container form-group">
+        <label class="info-label">
+          <span>Organization</span>
+        </label>
+        <span class="info-data form-control">
+          <span>{{submission.organization.name}}</span>
+        </span>
       </div>
     </li>
     <li class="list-unstyled" ng-repeat="fieldProfile in workflowStep.aggregateFieldProfiles | filter:{enabled: true}" ng-if="$index >= (workflowStep.aggregateFieldProfiles.length / 2) && fieldProfile.inputType.name !== 'INPUT_FILE'">


### PR DESCRIPTION
# VIR-50: Add Organization to admin reviewer page

Addresses: https://jhulibraries.atlassian.net/browse/VIR-50

## Summary

- Adds a read-only "Organization" field to the Personal Information tab on the admin submission reviewer page (we can't practically make it editable because other fields would need to dynamically change)
- Displays the organization the submission was submitted to (e.g. "Johns Hopkins University", "Krieger School of Arts and Sciences")
- Positioned at the top of the right column, above Major, matching the existing field styles

## History of what changed upstream between Vireo versions

 In Vireo 3, view.html had College and Department as direct fields on the submission (submission.getCollege(), submission.getDepartment()). There was no "Organization" field per se — the concept was modeled as "College" + "Department" directly on the submission.
 
 In Vireo 4, the architecture changed: College and Department became configurable field profiles in the workflow, and the structural concept became submission.organization. The College/Department fields are still there as workflow-configured field values, but the organization (which org the submission was submitted to) is a separate property that was never surfaced on the reviewer page.
 
## Change

### `src/main/webapp/app/views/admin/info/workflowStep.html`

Added a static `Organization` field to the right column of the Personal Information tab. Uses the same `info-container`, `info-label`, and `info-data form-control` classes as the dynamic field profiles for visual consistency.

The field is:
- **Read-only** — no edit pencil icon, since changing the organization would affect downstream choices (department, degree, etc.) that were already made during submission
- **Only shown on the Personal Information tab** — gated by `workflowStep.name === 'Personal Information'`
- **Not a configurable field profile** — `submission.organization` is a property of the submission itself, not a field value. Adding it as a workflow field profile would require backend changes (new input type, new field predicate). The static display approach is appropriate for this use case.

## Related

- HELP-33229: Organization not showing up in Vireo on student submissions

## Test plan

- [x] Open a submission from admin/list — Organization should appear at the top of the right column on the Personal Information tab
- [x] Organization field should not have an edit icon
- [x] Organization should not appear on other tabs (License Agreement, Document Information)
- [x] Submissions to the root institution should show the root org name
- [x] Submissions to child organizations should show the child org name

<img width="1508" height="1522" alt="image" src="https://github.com/user-attachments/assets/ca1146f0-5b0a-4376-951b-25a8ea034119" />
