### PR TITLE
VIR-51: fall back to alt identifier when primary lookup misses

### DIFF
--- a/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
+++ b/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
@@ -68,6 +68,15 @@ public class VireoUserCredentialsService extends UserCredentialsService<User, Us
             ? userRepo.findByNetid(shibNetid)
             : userRepo.findByEmail(shibEmail);
 
+        // Fall back to the other identifier so a returning user whose email
+        // domain has changed (or netid has changed) is matched to their
+        // existing record instead of colliding on a unique constraint.
+        if (user == null) {
+            user = useNetidAsIdentifier
+                ? (StringUtils.isNotEmpty(shibEmail) ? userRepo.findByEmail(shibEmail) : null)
+                : (StringUtils.isNotEmpty(shibNetid) ? userRepo.findByNetid(shibNetid) : null);
+        }
+
         if (user == null) {
             Role role = Role.ROLE_STUDENT;
 

--- a/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
+++ b/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
@@ -113,7 +113,7 @@ public class VireoUserCredentialsService extends UserCredentialsService<User, Us
 
                 if (StringUtils.isNotEmpty(shibBirthYearValue)) {
                     int shibBirthYear = Integer.parseInt(shibBirthYearValue);
-                    if (shibBirthYear != user.getBirthYear()) {
+                    if (user.getBirthYear() == null || shibBirthYear != user.getBirthYear()) {
                         user.setBirthYear(shibBirthYear);
                         isUserUpdated = true;
                     }
@@ -125,7 +125,7 @@ public class VireoUserCredentialsService extends UserCredentialsService<User, Us
                 isUserUpdated = true;
             }
 
-            if (StringUtils.isNotEmpty(shibMiddleName) && !user.getMiddleName().equals(shibMiddleName)) {
+            if (StringUtils.isNotEmpty(shibMiddleName) && (user.getMiddleName() == null || !user.getMiddleName().equals(shibMiddleName))) {
                 user.setMiddleName(shibMiddleName);
                 isUserUpdated = true;
             }
@@ -135,7 +135,7 @@ public class VireoUserCredentialsService extends UserCredentialsService<User, Us
                 isUserUpdated = true;
             }
 
-            if (StringUtils.isNotEmpty(shibOrcid) && !user.getOrcid().equals(shibOrcid)) {
+            if (StringUtils.isNotEmpty(shibOrcid) && (user.getOrcid() == null || !user.getOrcid().equals(shibOrcid))) {
                 user.setOrcid(shibOrcid);
                 isUserUpdated = true;
             }

--- a/src/test/java/org/tdl/vireo/auth/service/VireoUserCredentialsServiceTest.java
+++ b/src/test/java/org/tdl/vireo/auth/service/VireoUserCredentialsServiceTest.java
@@ -1,0 +1,217 @@
+package org.tdl.vireo.auth.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tdl.vireo.model.Role;
+import org.tdl.vireo.model.User;
+import org.tdl.vireo.model.repo.ConfigurationRepo;
+import org.tdl.vireo.model.repo.UserRepo;
+
+import edu.tamu.weaver.auth.model.Credentials;
+
+@ExtendWith(MockitoExtension.class)
+public class VireoUserCredentialsServiceTest {
+
+    private static final String NETID = "yzhu92";
+    private static final String OLD_EMAIL = "yzhu92@jhmi.edu";
+    private static final String NEW_EMAIL = "yzhu92@jhu.edu";
+    private static final String FIRST_NAME = "Yining";
+    private static final String LAST_NAME = "Zhu";
+
+    @Mock
+    private ConfigurationRepo configurationRepo;
+
+    @Mock
+    private UserRepo userRepo;
+
+    @InjectMocks
+    private VireoUserCredentialsService service;
+
+    @BeforeEach
+    public void setup() {
+        // The userRepo field is inherited (protected) from UserCredentialsService<U, R>,
+        // so @InjectMocks doesn't always wire it. Set it explicitly.
+        ReflectionTestUtils.setField(service, "userRepo", userRepo);
+        ReflectionTestUtils.setField(service, "admins", new String[] {});
+        ReflectionTestUtils.setField(service, "useNetidAsIdentifier", false);
+
+        // No DB-configured Shibboleth attribute overrides — use defaults.
+        when(configurationRepo.getValueByNameAndType(anyString(), anyString())).thenReturn(null);
+    }
+
+    @Test
+    @DisplayName("Healthy login: primary lookup matches, fallback never runs")
+    public void primaryLookupMatches_fallbackNotInvoked() {
+        Credentials creds = credentialsWith(NETID, OLD_EMAIL, FIRST_NAME, LAST_NAME);
+        User existing = existingUser(NETID, OLD_EMAIL, FIRST_NAME, LAST_NAME);
+        when(userRepo.findByEmail(OLD_EMAIL)).thenReturn(existing);
+
+        User result = service.updateUserByCredentials(creds);
+
+        assertSame(existing, result);
+        verify(userRepo).findByEmail(OLD_EMAIL);
+        verify(userRepo, never()).findByNetid(anyString());
+        verify(userRepo, never()).create(anyString(), anyString(), anyString(), any(Role.class));
+    }
+
+    @Test
+    @DisplayName("VIR-51 fix: returning student, email changed, fallback by netid matches existing record")
+    public void emailMisses_fallbackByNetidFindsUser_emailUpdated() {
+        Credentials creds = credentialsWith(NETID, NEW_EMAIL, FIRST_NAME, LAST_NAME);
+        User existing = existingUser(NETID, OLD_EMAIL, FIRST_NAME, LAST_NAME);
+
+        when(userRepo.findByEmail(NEW_EMAIL)).thenReturn(null);
+        when(userRepo.findByNetid(NETID)).thenReturn(existing);
+        when(userRepo.save(existing)).thenReturn(existing);
+
+        User result = service.updateUserByCredentials(creds);
+
+        assertSame(existing, result);
+        assertEquals(NEW_EMAIL, existing.getEmail());
+        assertEquals(NEW_EMAIL, existing.getUsername());
+        verify(userRepo).findByEmail(NEW_EMAIL);
+        verify(userRepo).findByNetid(NETID);
+        verify(userRepo, never()).create(anyString(), anyString(), anyString(), any(Role.class));
+        verify(userRepo).save(existing);
+    }
+
+    @Test
+    @DisplayName("Symmetric fallback: useNetidAsIdentifier=true, netid changed, fallback by email matches")
+    public void netidMisses_fallbackByEmailFindsUser_netidUpdated() {
+        ReflectionTestUtils.setField(service, "useNetidAsIdentifier", true);
+
+        String newNetid = "yzhu92-new";
+        Credentials creds = credentialsWith(newNetid, OLD_EMAIL, FIRST_NAME, LAST_NAME);
+        User existing = existingUser(NETID, OLD_EMAIL, FIRST_NAME, LAST_NAME);
+
+        when(userRepo.findByNetid(newNetid)).thenReturn(null);
+        when(userRepo.findByEmail(OLD_EMAIL)).thenReturn(existing);
+        when(userRepo.save(existing)).thenReturn(existing);
+
+        User result = service.updateUserByCredentials(creds);
+
+        assertSame(existing, result);
+        assertEquals(newNetid, existing.getNetid());
+        verify(userRepo).findByNetid(newNetid);
+        verify(userRepo).findByEmail(OLD_EMAIL);
+        verify(userRepo, never()).create(anyString(), anyString(), anyString(), any(Role.class));
+        verify(userRepo).save(existing);
+    }
+
+    @Test
+    @DisplayName("Truly new user: both lookups miss, create branch runs")
+    public void bothLookupsMiss_createBranchRuns() {
+        Credentials creds = credentialsWith(NETID, NEW_EMAIL, FIRST_NAME, LAST_NAME);
+        User created = new User(NEW_EMAIL, FIRST_NAME, LAST_NAME, Role.ROLE_STUDENT);
+
+        when(userRepo.findByEmail(NEW_EMAIL)).thenReturn(null);
+        when(userRepo.findByNetid(NETID)).thenReturn(null);
+        when(userRepo.create(NEW_EMAIL, FIRST_NAME, LAST_NAME, Role.ROLE_STUDENT)).thenReturn(created);
+        when(userRepo.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = service.updateUserByCredentials(creds);
+
+        assertNotNull(result);
+        assertEquals(NETID, result.getNetid());
+        verify(userRepo).findByEmail(NEW_EMAIL);
+        verify(userRepo).findByNetid(NETID);
+        verify(userRepo).create(NEW_EMAIL, FIRST_NAME, LAST_NAME, Role.ROLE_STUDENT);
+        verify(userRepo).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("Null-safety: fallback-matched user with null optional fields does not NPE")
+    public void fallbackMatch_nullOptionalFieldsOnExistingUser_noNpe() {
+        Map<String, String> credentialMap = new HashMap<>();
+        credentialMap.put("netid", NETID);
+        credentialMap.put("email", NEW_EMAIL);
+        credentialMap.put("firstName", FIRST_NAME);
+        credentialMap.put("lastName", LAST_NAME);
+        credentialMap.put("middleName", "Q");
+        credentialMap.put("orcid", "0000-0000-0000-0001");
+        credentialMap.put("birthYear", "1990");
+
+        Credentials creds = new Credentials();
+        creds.setAllCredentials(credentialMap);
+
+        // Existing user has null optional fields — locally-registered account, then matched by fallback.
+        User existing = existingUser(NETID, OLD_EMAIL, FIRST_NAME, LAST_NAME);
+        // middleName, orcid, birthYear left at null (default).
+
+        when(userRepo.findByEmail(NEW_EMAIL)).thenReturn(null);
+        when(userRepo.findByNetid(NETID)).thenReturn(existing);
+        when(userRepo.save(existing)).thenReturn(existing);
+
+        assertDoesNotThrow(() -> service.updateUserByCredentials(creds));
+
+        assertEquals("Q", existing.getMiddleName());
+        assertEquals("0000-0000-0000-0001", existing.getOrcid());
+        assertEquals(Integer.valueOf(1990), existing.getBirthYear());
+        verify(userRepo).save(existing);
+    }
+
+    @Test
+    @DisplayName("Empty fallback identifier short-circuits: no repo call on the missing side")
+    public void emptyShibNetid_fallbackShortCircuits() {
+        // useNetidAsIdentifier=false (default). shibNetid is empty, so on email-miss the
+        // fallback's StringUtils.isNotEmpty(shibNetid) check should prevent findByNetid.
+        Map<String, String> credentialMap = new HashMap<>();
+        credentialMap.put("netid", ""); // empty
+        credentialMap.put("email", NEW_EMAIL);
+        credentialMap.put("firstName", FIRST_NAME);
+        credentialMap.put("lastName", LAST_NAME);
+
+        Credentials creds = new Credentials();
+        creds.setAllCredentials(credentialMap);
+
+        when(userRepo.findByEmail(NEW_EMAIL)).thenReturn(null);
+        when(userRepo.create(NEW_EMAIL, FIRST_NAME, LAST_NAME, Role.ROLE_STUDENT))
+            .thenReturn(new User(NEW_EMAIL, FIRST_NAME, LAST_NAME, Role.ROLE_STUDENT));
+        when(userRepo.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.updateUserByCredentials(creds);
+
+        verify(userRepo).findByEmail(NEW_EMAIL);
+        verify(userRepo, never()).findByNetid(anyString());
+        verify(userRepo).create(NEW_EMAIL, FIRST_NAME, LAST_NAME, Role.ROLE_STUDENT);
+    }
+
+    // --- helpers ---
+
+    private Credentials credentialsWith(String netid, String email, String first, String last) {
+        Map<String, String> map = new HashMap<>();
+        map.put("netid", netid);
+        map.put("email", email);
+        map.put("firstName", first);
+        map.put("lastName", last);
+        Credentials c = new Credentials();
+        c.setAllCredentials(map);
+        return c;
+    }
+
+    private User existingUser(String netid, String email, String first, String last) {
+        User u = new User(email, first, last, Role.ROLE_STUDENT);
+        u.setNetid(netid);
+        u.setUsername(email);
+        return u;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes login 500 for returning students whose email domain changed between submissions (e.g., `@jhmi.edu` → `@jhu.edu`). Adds a fallback identifier lookup in `VireoUserCredentialsService.updateUserByCredentials` so the existing user record is found instead of triggering a unique-constraint violation on insert. Also tightens three null-safe field comparisons in the existing update block (same pattern as the prior `21d3b57f0` "Null check netid" fix) and adds unit-test coverage for the service.

Refs VIR-51, HELP-32864.

## Background

A returning JHU student tried to log in with JHED and got a 500. The cause:

1. `useNetidAsIdentifier: false` (our default) → user lookup goes by email.
2. The student's email domain had changed since their last submission, so `findByEmail` returned `null`.
3. The "create new user" branch ran with the existing netid attached.
4. `userRepo.save(user)` violated the unique constraint on `weaver_users.netid` → 500.

The same failure mode exists symmetrically for institutions running with `useNetidAsIdentifier: true` if a netid changes but the email is stable — the email unique constraint blows up the create.

## What this PR does

### 1. Fallback identifier lookup

Single fallback lookup, symmetric for both modes:

```java
User user = useNetidAsIdentifier
    ? userRepo.findByNetid(shibNetid)
    : userRepo.findByEmail(shibEmail);

// Fall back to the other identifier so a returning user whose email
// domain has changed (or netid has changed) is matched to their
// existing record instead of colliding on a unique constraint.
if (user == null) {
    user = useNetidAsIdentifier
        ? (StringUtils.isNotEmpty(shibEmail) ? userRepo.findByEmail(shibEmail) : null)
        : (StringUtils.isNotEmpty(shibNetid) ? userRepo.findByNetid(shibNetid) : null);
}
```

The existing `else` block (post-`21d3b57f0` "Null check netid") already handles syncing the changed field onto the matched row — netid update at the top, email/username update at the bottom. So a returning student is matched to their existing record and their email is brought up to date on next login. No new row, no constraint violation, no 500.

### 2. Null-safe optional field comparisons

The new fallback can route locally-registered accounts (which leave `birthYear`, `middleName`, and `orcid` as `null`) into the update branch. Without guards, the comparisons there NPE when Shibboleth provides values for those fields:

```java
// birthYear — auto-unbox NPE risk
if (user.getBirthYear() == null || shibBirthYear != user.getBirthYear()) { ... }

// middleName — null.equals() NPE risk
if (StringUtils.isNotEmpty(shibMiddleName) && (user.getMiddleName() == null || !user.getMiddleName().equals(shibMiddleName))) { ... }

// orcid — null.equals() NPE risk
if (StringUtils.isNotEmpty(shibOrcid) && (user.getOrcid() == null || !user.getOrcid().equals(shibOrcid))) { ... }
```

Same pattern as the prior `21d3b57f0` fix for `netid`. Doesn't change behavior for users whose fields are already populated.

### 3. Unit test coverage

New `VireoUserCredentialsServiceTest` (6 cases) — the service previously had no unit tests:

| Test | Pins |
|---|---|
| `primaryLookupMatches_fallbackNotInvoked` | Healthy login — fallback never runs |
| `emailMisses_fallbackByNetidFindsUser_emailUpdated` | The VIR-51 fix path (JHU's `useNetidAsIdentifier=false` case) |
| `netidMisses_fallbackByEmailFindsUser_netidUpdated` | Symmetric case for `useNetidAsIdentifier=true` |
| `bothLookupsMiss_createBranchRuns` | Truly-new-user path unchanged |
| `fallbackMatch_nullOptionalFieldsOnExistingUser_noNpe` | The three null-safety guards |
| `emptyShibNetid_fallbackShortCircuits` | The `StringUtils.isNotEmpty` guard prevents stray repo calls |

Mockito-only, no DB. ~1 second to run.

## What this PR is *not*

- **Not a data migration.** We have pre-existing duplicate-netid pairs in our DB from older code paths. This PR prevents new duplicates from forming; cleanup of the existing ones is a separate task.
- **Not a behavior change for healthy logins.** When the primary identifier matches an existing row, the fallback never runs. Zero diff for the success path.
- **Not a change to `useNetidAsIdentifier` semantics.** The flag still picks the *primary* identifier; the fallback only kicks in on miss.

## Edge cases considered

| Case | Behavior with the fix |
|---|---|
| Primary lookup matches | Fallback never runs. Identical to today. |
| Primary misses, fallback finds row | Existing update block syncs the changed field. No new row created. |
| Primary misses, fallback also misses | Falls through to create-new-user. Identical to today. |
| Shibboleth omits one of the two attributes | Empty-string guard short-circuits the fallback. |
| Fallback matches a row with `null` optional fields | Null-safety guards prevent NPE; fields are populated from the Shibboleth assertion. |
| Primary misses, fallback finds row whose secondary identifier *also* differs from Shibboleth | Row is updated rather than a 500 surfaced. The current code already updates email/netid on every login when they differ from what's stored, so this PR doesn't grant Shibboleth any new authority — only changes the lookup to match the authority the rest of the method already grants it. |

## Test plan

- [x] Unit tests pass: `mvn test -Dtest=VireoUserCredentialsServiceTest`
- [ ] Smoke test: log in as an existing user (default email path) — confirm normal login still works
- [ ] Smoke test: log in with brand-new netid and email — confirm new user is still created (fallthrough path unchanged)
- [ ] `mvn compile` is clean

## Notes for reviewers

- The original commit landed directly on `v4.3.2-JHU` by mistake (`a697bbed5`). I reverted it (`b8f9f86aa`) and re-opened the change as this PR for proper review.
